### PR TITLE
[unitaryHACK] Add type hints to `sequence.py` (#16) (#167)

### DIFF
--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -12,32 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import namedtuple
-from collections.abc import Iterable
+from collections.abc import Callable, Generator, Iterable, Set
 import copy
 from functools import wraps
 from itertools import chain
 import json
+from sys import version_info
+from typing import Any, cast, NamedTuple, Optional, Tuple, Union
 import warnings
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 import pulser
-from pulser.pulse import Pulse
+from pulser.channels import Channel
 from pulser.devices import MockDevice
 from pulser.devices._device_datacls import Device
 from pulser.json.coders import PulserEncoder, PulserDecoder
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized, Variable
+from pulser.pulse import Pulse
+from pulser.register import Register
 from pulser._seq_drawer import draw_sequence
 
-# Auxiliary class to store the information in the schedule
-_TimeSlot = namedtuple('_TimeSlot', ['type', 'ti', 'tf', 'targets'])
+if version_info[:2] == (3, 7):  # pragma: no cover
+    try:
+        from typing_extensions import Literal, get_args
+    except ImportError:
+        raise ImportError(
+            "Using pulser with Python version 3.7 requires the"
+            " `typing_extensions` module. Install it by running"
+            " `pip install typing-extensions`.")
+else:  # pragma: no cover
+    from typing import Literal, get_args  # type: ignore
+
+
+QubitId = Union[int, str]
+PROTOCOLS = Literal['min-delay', 'no-delay', 'wait-for-all']
+
+
+class _TimeSlot(NamedTuple):
+    """Auxiliary class to store the information in the schedule."""
+    type: Union[Pulse, str]
+    ti: int
+    tf: int
+    targets: Set[QubitId]
+
+
 # Encodes a sequence building calls
 _Call = namedtuple("_Call", ['name', 'args', 'kwargs'])
 
 
-def _screen(func):
+def _screen(func: Callable) -> Callable:
     """Blocks the call to a function if the Sequence is parametrized."""
     @wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -48,7 +77,7 @@ def _screen(func):
     return wrapper
 
 
-def _store(func):
+def _store(func: Callable) -> Callable:
     """Stores any Sequence building call for deferred execution."""
     @wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -65,7 +94,7 @@ def _store(func):
                             "Sequence. Use only what's returned by this"
                             "Sequence's 'declare_variable' method as your"
                             "variables."
-                            )
+                        )
             elif isinstance(x, Iterable) and not isinstance(x, str):
                 # Recursively look for parametrized objs inside the arguments
                 for y in x:
@@ -115,7 +144,8 @@ class Sequence:
         The register and device do not support variable parameters. As such,
         they are the same for all Sequences built from a parametrized Sequence.
     """
-    def __init__(self, register, device):
+
+    def __init__(self, register: Register, device: Device):
         """Initializes a new pulse sequence."""
         if not isinstance(device, Device):
             raise TypeError("'device' must be of type 'Device'. Import a valid"
@@ -133,39 +163,46 @@ class Sequence:
         # Checks if register is compatible with the device
         device.validate_register(register)
 
-        self._register = register
-        self._device = device
-        self._in_xy = False
-        self._calls = [_Call("__init__", (register, device), {})]
-        self._channels = {}
-        self._schedule = {}
-        self._phase_ref = {}  # The phase reference of each channel
-        # Stores the names and corresponding ids of declared channels
-        self._taken_channels = {}
-        self._qids = set(self.qubit_info.keys())  # IDs of all qubits in device
-        self._last_used = {}    # Last time each qubit was used, by basis
-        self._last_target = {}  # Last time a target happened, by channel
+        self._register: Register = register
+        self._device: Device = device
+        self._in_xy: bool = False
+        self._calls: list[_Call] = [_Call("__init__", (register, device), {})]
+        self._channels: dict[str, Channel] = {}
+        self._schedule: dict[str, list[_TimeSlot]] = {}
+        # The phase reference of each channel
+        self._phase_ref: dict[str, dict[QubitId, _PhaseTracker]] = {}
+        # Stores the names and dict ids of declared channels
+        self._taken_channels: dict[str, str] = {}
+        # IDs of all qubits in device
+        self._qids: set[QubitId] = set(self.qubit_info.keys())
+        # Last time each qubit was used, by basis
+        self._last_used: dict[str, dict[QubitId, int]] = {}
+        # Last time a target happened, by channel
+        self._last_target: dict[str, int] = {}
+        self._variables: dict[str, Variable] = {}
+        self._to_build_calls: list[_Call] = []
+        self._building: bool = True
 
         # Initializes all parametrized Sequence related attributes
         self._reset_parametrized()
 
     @property
-    def qubit_info(self):
+    def qubit_info(self) -> dict[QubitId, np.ndarray]:
         """Dictionary with the qubit's IDs and positions."""
         return self._register.qubits
 
     @property
-    def declared_channels(self):
+    def declared_channels(self) -> dict[str, Channel]:
         """Channels declared in this Sequence."""
         return dict(self._channels)
 
     @property
-    def declared_variables(self):
+    def declared_variables(self) -> dict[str, Variable]:
         """Variables declared in this Sequence."""
         return dict(self._variables)
 
     @property
-    def available_channels(self):
+    def available_channels(self) -> dict[str, Channel]:
         """Channels still available for declaration."""
         # Show all channels if none are declared, otherwise filter depending
         # on whether the sequence is working on XY mode
@@ -179,7 +216,7 @@ class Sequence:
                     and (ch.basis == 'XY' if self._in_xy else ch.basis != 'XY')
                     }
 
-    def is_parametrized(self):
+    def is_parametrized(self) -> bool:
         """States whether the sequence is parametrized.
 
         A parametrized sequence is one that depends on the values assigned to
@@ -193,7 +230,8 @@ class Sequence:
         return not self._building
 
     @_screen
-    def current_phase_ref(self, qubit, basis='digital'):
+    def current_phase_ref(self, qubit: QubitId,
+                          basis: str = 'digital') -> float:
         """Current phase reference of a specific qubit for a given basis.
 
         Args:
@@ -217,7 +255,11 @@ class Sequence:
 
         return self._phase_ref[basis][qubit].last_phase
 
-    def declare_channel(self, name, channel_id, initial_target=None):
+    def declare_channel(self, name: str, channel_id: str,
+                        initial_target: Optional[
+                            Union[Iterable[Union[QubitId, Parametrized]],
+                                  Union[QubitId, Parametrized]]] = None
+                        ) -> None:
         """Declares a new channel to the Sequence.
 
         The first declared channel implicitly defines the sequence's mode of
@@ -239,10 +281,10 @@ class Sequence:
                 description.
 
         Keyword Args:
-            initial_target (set, default=None): For 'Local' addressing channels
-                only. Declares the initial target of the channel. If left as
-                None, the initial target will have to be set manually as the
-                first addition to this channel.
+            initial_target (Iterable, default=None): For 'Local' addressing
+                channels only. Declares the initial target of the channel.
+                If left as None, the initial target will have to be set
+                manually as the first addition to this channel.
         """
 
         if name in self._channels:
@@ -279,7 +321,8 @@ class Sequence:
             self._add_to_schedule(name, _TimeSlot('target', -1, 0, self._qids))
         elif initial_target is not None:
             try:
-                cond = any(isinstance(t, Parametrized) for t in initial_target)
+                cond = any(isinstance(t, Parametrized)
+                           for t in cast(Iterable, initial_target))
             except TypeError:
                 cond = isinstance(initial_target, Parametrized)
             if cond:
@@ -292,15 +335,17 @@ class Sequence:
                 initial_target = None
             else:
                 # "_target" call is not saved
-                self._target(initial_target, name)
+                self._target(cast(Union[Iterable,
+                                        QubitId], initial_target), name)
 
         # Manually store the channel declaration as a regular call
-        self._calls.append(_Call(
-                            "declare_channel",
-                            (name, channel_id),
-                            {"initial_target": initial_target}))
+        self._calls.append(_Call("declare_channel", (name, channel_id),
+                                 {"initial_target": initial_target}))
 
-    def declare_variable(self, name, size=1, dtype=float):
+    def declare_variable(self, name: str, size: int = 1,
+                         dtype: Union[type[int],
+                                      type[float],
+                                      type[str]] = float) -> Variable:
         """Declare a new variable within this Sequence.
 
         The declared variables can be used to create parametrized versions of
@@ -332,7 +377,9 @@ class Sequence:
         return var
 
     @_store
-    def add(self, pulse, channel, protocol='min-delay'):
+    def add(self, pulse: Union[Pulse, Parametrized],
+            channel: Union[str, Parametrized],
+            protocol: PROTOCOLS = 'min-delay') -> None:
         """Adds a pulse to a channel.
 
         Args:
@@ -356,9 +403,12 @@ class Sequence:
                     idles the channel until the end of the other channels'
                     latest pulse.
         """
+        pulse = cast(Pulse, pulse)
+        channel = cast(str, channel)
+
         self._validate_channel(channel)
 
-        valid_protocols = ['min-delay', 'no-delay', 'wait-for-all']
+        valid_protocols = get_args(PROTOCOLS)
         if protocol not in valid_protocols:
             raise ValueError(f"Invalid protocol '{protocol}', only accepts "
                              "protocols: " + ", ".join(valid_protocols))
@@ -425,16 +475,17 @@ class Sequence:
 
         self._add_to_schedule(channel, _TimeSlot(pulse, ti, tf, last.targets))
 
-        for q in last.targets:
-            if self._last_used[basis][q] < tf:
-                self._last_used[basis][q] = tf
+        for qubit in last.targets:
+            if self._last_used[basis][qubit] < tf:
+                self._last_used[basis][qubit] = tf
 
         if pulse.post_phase_shift:
             self._phase_shift(pulse.post_phase_shift, *last.targets,
                               basis=basis)
 
     @_store
-    def target(self, qubits, channel):
+    def target(self, qubits: Union[QubitId, Iterable[QubitId], Parametrized],
+               channel: Union[str, Parametrized]) -> None:
         """Changes the target qubit of a 'Local' channel.
 
         Args:
@@ -444,20 +495,28 @@ class Sequence:
             channel (str): The channel's name provided when declared. Must be
                 a channel with 'Local' addressing.
          """
+        qubits = cast(QubitId, qubits)
+        channel = cast(str, channel)
+
         self._target(qubits, channel)
 
     @_store
-    def delay(self, duration, channel):
+    def delay(self, duration: Union[int, Parametrized],
+              channel: Union[str, Parametrized]) -> None:
         """Idles a given channel for a specific duration.
 
         Args:
             duration (int): Time to delay (in multiples of 4 ns).
             channel (str): The channel's name provided when declared.
         """
+        duration = cast(int, duration)
+        channel = cast(str, channel)
+
         self._delay(duration, channel)
 
     @_store
-    def measure(self, basis='ground-rydberg'):
+    def measure(self,
+                basis: Union[str, Parametrized] = 'ground-rydberg') -> None:
         """Measures in a valid basis.
 
         Note:
@@ -489,7 +548,9 @@ class Sequence:
             self._measurement = basis
 
     @_store
-    def phase_shift(self, phi, *targets, basis='digital'):
+    def phase_shift(self, phi: Union[float, Parametrized],
+                    *targets: Union[QubitId, Parametrized],
+                    basis: Union[str, Parametrized] = 'digital') -> None:
         r"""Shifts the phase of a qubit's reference by 'phi', for a given basis.
 
         This is equivalent to an :math:`R_z(\phi)` gate (i.e. a rotation of the
@@ -506,10 +567,14 @@ class Sequence:
                 the phase shift to. Must correspond to the basis of a declared
                 channel.
         """
+        phi = cast(float, phi)
+        basis = cast(str, basis)
+        targets = cast(Tuple[QubitId], targets)
+
         self._phase_shift(phi, *targets, basis=basis)
 
     @_store
-    def align(self, *channels):
+    def align(self, *channels: Union[str, Parametrized]) -> None:
         """Aligns multiple channels in time.
 
         Introduces delays that align the provided channels with the one that
@@ -535,15 +600,15 @@ class Sequence:
         if self.is_parametrized():
             return
 
-        last_ts = {id: self._last(id).tf for id in channels}
+        last_ts = {id: self._last(cast(str, id)).tf for id in channels}
         tf = max(last_ts.values())
 
         for id in channels:
             delta = tf - last_ts[id]
             if delta > 0:
-                self._delay(delta, id)
+                self._delay(delta, cast(str, id))
 
-    def build(self, **vars):
+    def build(self, **vars: Union[ArrayLike, float, int, str]) -> Sequence:
         """Builds a sequence from the programmed instructions.
 
         Keyword Args:
@@ -600,7 +665,7 @@ class Sequence:
 
         return seq
 
-    def serialize(self, **kwargs):
+    def serialize(self, **kwargs: Any) -> str:
         """Serializes the Sequence into a JSON formatted string.
 
         Other Parameters:
@@ -617,7 +682,7 @@ class Sequence:
         return json.dumps(self, cls=PulserEncoder, **kwargs)
 
     @staticmethod
-    def deserialize(obj, **kwargs):
+    def deserialize(obj: str, **kwargs: Any) -> Sequence:
         """Deserializes a JSON formatted string.
 
         Args:
@@ -640,68 +705,68 @@ class Sequence:
             warnings.warn("The given JSON formatted string does not encode a "
                           "Sequence.")
 
-        return json.loads(obj, cls=PulserDecoder, **kwargs)
+        return cast(Sequence, json.loads(obj, cls=PulserDecoder, **kwargs))
 
     @_screen
-    def draw(self, draw_phase_area=False):
+    def draw(self, draw_phase_area: bool = False) -> None:
         """Draws the sequence in its current state.
 
         Keyword args:
             draw_phase_area (bool): Whether phase and area values need
                 to be shown as text on the plot, defaults to False.
         """
-        draw_sequence(
-            self, draw_phase_area=draw_phase_area,
-        )
+        draw_sequence(self, draw_phase_area=draw_phase_area)
 
-    def _target(self, qubits, channel):
+    def _target(self, qubits: Union[Iterable[QubitId],
+                                    QubitId], channel: str) -> None:
         self._validate_channel(channel)
 
         try:
-            qs = set(qubits) if not isinstance(qubits, str) else {qubits}
+            qubits_set = set(cast(Iterable, qubits)) if not isinstance(
+                qubits, str) else {qubits}
         except TypeError:
-            qs = {qubits}
+            qubits_set = {qubits}
 
         if self._channels[channel].addressing != 'Local':
             raise ValueError("Can only choose target of 'Local' channels.")
-        elif len(qs) > self._channels[channel].max_targets:
+        elif len(qubits_set) > self._channels[channel].max_targets:
             raise ValueError(
                 "This channel can target at most "
                 f"{self._channels[channel].max_targets} qubits at a time"
             )
 
         if self.is_parametrized():
-            for q in qs:
+            for q in qubits_set:
                 if q not in self._qids and not isinstance(q, Parametrized):
                     raise ValueError("All non-variable qubits must belong to "
                                      "the register.")
             return
 
-        elif not qs.issubset(self._qids):
+        elif not qubits_set.issubset(self._qids):
             raise ValueError("All given qubits must belong to the register.")
 
         basis = self._channels[channel].basis
-        phase_refs = {self._phase_ref[basis][q].last_phase for q in qs}
+        phase_refs = {self._phase_ref[basis][q].last_phase for q in qubits_set}
         if len(phase_refs) != 1:
             raise ValueError("Cannot target multiple qubits with different "
                              "phase references for the same basis.")
 
         try:
             last = self._last(channel)
-            if last.targets == qs:
+            if last.targets == qubits_set:
                 warnings.warn("The provided qubits are already the target. "
                               "Skipping this target instruction.")
                 return
             ti = last.tf
-            retarget = self._channels[channel].retarget_time
+            retarget = cast(int, self._channels[channel].retarget_time)
             elapsed = ti - self._last_target[channel]
-            delta = np.clip(retarget - elapsed, 0, retarget)
+            delta = cast(int, np.clip(retarget - elapsed, 0, retarget))
             if delta != 0:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     delta = self._channels[channel].validate_duration(
-                        np.clip(delta, 16, np.inf)
-                        )
+                        cast(int, np.clip(delta, 16, np.inf))
+                    )
             tf = ti + delta
 
         except ValueError:
@@ -709,9 +774,9 @@ class Sequence:
             tf = 0
 
         self._last_target[channel] = tf
-        self._add_to_schedule(channel, _TimeSlot('target', ti, tf, qs))
+        self._add_to_schedule(channel, _TimeSlot('target', ti, tf, qubits_set))
 
-    def _delay(self, duration, channel):
+    def _delay(self, duration: int, channel: str) -> None:
         self._validate_channel(channel)
         if self.is_parametrized():
             return
@@ -722,7 +787,8 @@ class Sequence:
         self._add_to_schedule(channel,
                               _TimeSlot('delay', ti, tf, last.targets))
 
-    def _phase_shift(self, phi, *targets, basis='digital'):
+    def _phase_shift(self, phi: float, *targets: QubitId,
+                     basis: str = 'digital') -> None:
         if basis not in self._phase_ref:
             raise ValueError("No declared channel targets the given 'basis'.")
         if self.is_parametrized():
@@ -741,12 +807,12 @@ class Sequence:
                           "it will be ommited.")
             return
 
-        for q in targets:
-            t = self._last_used[basis][q]
-            new_phase = self._phase_ref[basis][q].last_phase + phi
-            self._phase_ref[basis][q][t] = new_phase
+        for qubit in targets:
+            last_used = self._last_used[basis][qubit]
+            new_phase = self._phase_ref[basis][qubit].last_phase + phi
+            self._phase_ref[basis][qubit][last_used] = new_phase
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, Any]:
         d = obj_to_dict(self, *self._calls[0].args, **self._calls[0].kwargs)
         d["__version__"] = pulser.__version__
         d["calls"] = self._calls[1:]
@@ -754,7 +820,7 @@ class Sequence:
         d["to_build_calls"] = self._to_build_calls
         return d
 
-    def __str__(self):
+    def __str__(self) -> str:
         full = ""
         pulse_line = "t: {}->{} | {} | Targets: {}\n"
         target_line = "t: {}->{} | Target: {} | Phase Reference: {}\n"
@@ -799,27 +865,27 @@ class Sequence:
 
         return full
 
-    def _add_to_schedule(self, channel, timeslot):
+    def _add_to_schedule(self, channel: str, timeslot: _TimeSlot) -> None:
         if hasattr(self, "_measurement"):
             raise SystemError("The sequence has already been measured. "
                               "Nothing more can be added.")
         self._schedule[channel].append(timeslot)
 
-    def _last(self, channel):
+    def _last(self, channel: str) -> _TimeSlot:
         """Shortcut to last element in the channel's schedule."""
         try:
             return self._schedule[channel][-1]
         except IndexError:
             raise ValueError("The chosen channel has no target.")
 
-    def _validate_channel(self, channel):
+    def _validate_channel(self, channel: str) -> None:
         if channel not in self._channels:
             raise ValueError("Use the name of a declared channel.")
 
-    def _validate_pulse(self, pulse, channel):
+    def _validate_pulse(self, pulse: Pulse, channel: str) -> None:
         self._device.validate_pulse(pulse, self._taken_channels[channel])
 
-    def _reset_parametrized(self):
+    def _reset_parametrized(self) -> None:
         """Resets all attributes related to parametrization."""
         # Signals the sequence as actively "building" ie not parametrized
         self._building = True
@@ -831,39 +897,41 @@ class Sequence:
 class _PhaseTracker:
     """Tracks a phase reference over time."""
 
-    def __init__(self, initial_phase):
-        self._times = [0]
-        self._phases = [self._format(initial_phase)]
+    def __init__(self, initial_phase: float):
+        self._times: list[int] = [0]
+        self._phases: list[float] = [self._format(initial_phase)]
 
     @property
-    def last_time(self):
+    def last_time(self) -> int:
         return self._times[-1]
 
     @property
-    def last_phase(self):
+    def last_phase(self) -> float:
         return self._phases[-1]
 
-    def changes(self, ti, tf, time_scale=1):
+    def changes(self, ti: Union[float, int], tf: Union[float, int],
+                time_scale: float = 1.) -> Generator[tuple[float, float],
+                                                     None, None]:
         """Changes in phases within ]ti, tf]."""
         start, end = np.searchsorted(
-                self._times, (ti * time_scale, tf * time_scale), side='right')
+            self._times, (ti * time_scale, tf * time_scale), side='right')
         for i in range(start, end):
             change = self._phases[i] - self._phases[i-1]
             yield (self._times[i] / time_scale, change)
 
-    def _format(self, phi):
+    def _format(self, phi: float) -> float:
         return phi % (2 * np.pi)
 
-    def __setitem__(self, t, phi):
+    def __setitem__(self, t: int, phi: float) -> None:
         phase = self._format(phi)
         if t in self._times:
             ind = self._times.index(t)
             self._phases[ind] = phase
         else:
-            ind = np.searchsorted(self._times, t, side='right')
+            ind = int(np.searchsorted(self._times, t, side='right'))
             self._times.insert(ind, t)
             self._phases.insert(ind, phase)
 
-    def __getitem__(self, t):
-        ind = np.searchsorted(self._times, t, side='right') - 1
+    def __getitem__(self, t: int) -> float:
+        ind = int(np.searchsorted(self._times, t, side='right')) - 1
         return self._phases[ind]


### PR DESCRIPTION
* Add type hints to sequence.py

* Update type hints in `sequence.py`

* Update type hints in `sequence.py`

* Introduce QubitId type

* Update QubitId definition

* Use built-in type hints

* Resolve merge conflicts

* Switch tuple to Tuple

* Update with PR comments

* Update with PR comments

* Add NamedTuple type hint

* Import Literal from typing_extensions

* Update with PR comments

* Change Set back to Iterable

* Change Iterable[QubitId] to Iterable

* Change comment to docstring

* Import Literal and get_args depending on version

* Add another # pragma: no cover

* Rearrange imports

* Rearrange imports

* Add a line, just a line

Co-authored-by: Henrique Silvério <henrique.silverio@tecnico.ulisboa.pt>